### PR TITLE
Add print_project_file action, print 3MF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ See [device triggers](docs/DeviceTrigger.md).
 
 * **Send Command**: Sends arbitrary GCODE to the printer. Be careful as it does not check if the printer is running a job
 or not so before invoking this action, you should check the printer state to ensure it is not running a job.
+*  **Print 3MF project file**: Prints 3MF file stored on SD card. 3MF file must be stored on SD card root and it must contain gcode (e.g., "Export sliced file" from slicer)
 
 ## Example dashboard
 

--- a/custom_components/bambu_lab/__init__.py
+++ b/custom_components/bambu_lab/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.helpers import entity_platform
 from .const import DOMAIN, LOGGER, PLATFORMS
 from .coordinator import BambuDataUpdateCoordinator
 from .config_flow import CONFIG_VERSION
-from .pybambu.commands import SEND_GCODE_TEMPLATE, PRINT_GCODE_FILE_TEMPLATE
+from .pybambu.commands import SEND_GCODE_TEMPLATE, PRINT_PROJECT_FILE_TEMPLATE
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the Bambu Lab integration."""
@@ -30,17 +30,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         send_command    # Handler function
     )
 
-    async def print_gcode_file(call: ServiceCall):
+    async def print_project_file(call: ServiceCall):
         """Handle the service call."""
-        command = PRINT_GCODE_FILE_TEMPLATE
-        command['print']['param'] = call.data.get("filepath")
+        command = PRINT_PROJECT_FILE_TEMPLATE
+        file = call.data.get("filepath")
+        plate = call.data.get("plate")
+
+        command["print"]["param"] = f"Metadata/plate_{plate}.gcode"
+        command["print"]["url"] = f"ftp://{file}"
+
         coordinator.client.publish(command)
 
     # Register the service with Home Assistant
     hass.services.async_register(
         DOMAIN,
-        "print_gcode_file",  # Service name
-        print_gcode_file  # Handler function
+        "print_project_file",  # Service name
+        print_project_file  # Handler function
     )
 
     # Set up all platforms for this device/entry.

--- a/custom_components/bambu_lab/__init__.py
+++ b/custom_components/bambu_lab/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.helpers import entity_platform
 from .const import DOMAIN, LOGGER, PLATFORMS
 from .coordinator import BambuDataUpdateCoordinator
 from .config_flow import CONFIG_VERSION
-from .pybambu.commands import SEND_GCODE_TEMPLATE
+from .pybambu.commands import SEND_GCODE_TEMPLATE, PRINT_GCODE_FILE_TEMPLATE
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the Bambu Lab integration."""
@@ -19,7 +19,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def send_command(call: ServiceCall):
         """Handle the service call."""
         command = SEND_GCODE_TEMPLATE
-        command['print']['param'] = f"{call.data.get("command")}\n"
+        command['print']['param'] = f"{call.data.get('command')}\n"
         coordinator.client.publish(command)
 
 
@@ -28,6 +28,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         DOMAIN,
         "send_command",  # Service name
         send_command    # Handler function
+    )
+
+    async def print_gcode_file(call: ServiceCall):
+        """Handle the service call."""
+        command = PRINT_GCODE_FILE_TEMPLATE
+        command['print']['param'] = call.data.get("filepath")
+        coordinator.client.publish(command)
+
+    # Register the service with Home Assistant
+    hass.services.async_register(
+        DOMAIN,
+        "print_gcode_file",  # Service name
+        print_gcode_file  # Handler function
     )
 
     # Set up all platforms for this device/entry.

--- a/custom_components/bambu_lab/pybambu/commands.py
+++ b/custom_components/bambu_lab/pybambu/commands.py
@@ -19,6 +19,7 @@ PUSH_ALL = {"pushing": {"sequence_id": "0", "command": "pushall"}}
 START_PUSH = { "pushing": {"sequence_id": "0", "command": "start"}}
 
 SEND_GCODE_TEMPLATE = {"print": {"sequence_id": "0", "command": "gcode_line", "param": ""}} # param = GCODE_EACH_LINE_SEPARATED_BY_\n
+PRINT_GCODE_FILE_TEMPLATE = {"print": {"sequence_id": "0", "command": "gcode_file", "param": ""}}
 
 # X1 only currently
 GET_ACCESSORIES = {"system": {"sequence_id": "0", "command": "get_accessories", "accessory_type": "none"}}

--- a/custom_components/bambu_lab/pybambu/commands.py
+++ b/custom_components/bambu_lab/pybambu/commands.py
@@ -19,7 +19,26 @@ PUSH_ALL = {"pushing": {"sequence_id": "0", "command": "pushall"}}
 START_PUSH = { "pushing": {"sequence_id": "0", "command": "start"}}
 
 SEND_GCODE_TEMPLATE = {"print": {"sequence_id": "0", "command": "gcode_line", "param": ""}} # param = GCODE_EACH_LINE_SEPARATED_BY_\n
-PRINT_GCODE_FILE_TEMPLATE = {"print": {"sequence_id": "0", "command": "gcode_file", "param": ""}}
+PRINT_PROJECT_FILE_TEMPLATE = {
+                "print": {
+                    "sequence_id": 0,
+                    "command": "project_file",
+                    "param": "", # param = f"Metadata/plate_1.gcode"
+                    "url": "", # url = f"ftp://{file}"
+                    "subtask_name": "",
+                    "bed_type": "auto",
+                    "timelapse": False,
+                    "bed_leveling": True,
+                    "flow_cali": False,
+                    "vibration_cali": True,
+                    "layer_inspect": False,
+                    "use_ams": False,
+                    "profile_id": "0",
+                    "project_id": "0",
+                    "subtask_id": "0",
+                    "task_id": "0",
+                }
+            }
 
 # X1 only currently
 GET_ACCESSORIES = {"system": {"sequence_id": "0", "command": "get_accessories", "accessory_type": "none"}}

--- a/custom_components/bambu_lab/services.yaml
+++ b/custom_components/bambu_lab/services.yaml
@@ -11,8 +11,8 @@ send_command:
         text:
 
 print_project_file:
-  name: Print sliced 3MF file
-  description: Print 3MF file stored on the SD card
+  name: Print 3MF project file
+  description: Print sliced 3MF file stored on the SD card
   fields:
     filepath:
       name: File path
@@ -24,8 +24,7 @@ print_project_file:
     plate:
       name: Plate number
       description: Plate number to print
-      required: false
-      example: "filename.3mf"
+      required: true
       default: 1
       selector:
         number:

--- a/custom_components/bambu_lab/services.yaml
+++ b/custom_components/bambu_lab/services.yaml
@@ -10,14 +10,23 @@ send_command:
       selector:
         text:
 
-print_gcode_file:
-  name: Print gcode file
-  description: Print gcode file by providing absolute path from SD card
+print_project_file:
+  name: Print sliced 3MF file
+  description: Print 3MF file stored on the SD card
   fields:
     filepath:
       name: File path
-      description: Absolute file path on SD card
+      description: Filename on SD card
       required: true
-      example: "models/3D_Benchy.gcode"
+      example: "filename.3mf"
       selector:
         text:
+    plate:
+      name: Plate number
+      description: Plate number to print
+      required: false
+      example: "filename.3mf"
+      default: 1
+      selector:
+        number:
+          min: 1

--- a/custom_components/bambu_lab/services.yaml
+++ b/custom_components/bambu_lab/services.yaml
@@ -9,3 +9,15 @@ send_command:
       example: "M104 S200"
       selector:
         text:
+
+print_gcode_file:
+  name: Print gcode file
+  description: Print gcode file by providing absolute path from SD card
+  fields:
+    filepath:
+      name: File path
+      description: Absolute file path on SD card
+      required: true
+      example: "models/3D_Benchy.gcode"
+      selector:
+        text:


### PR DESCRIPTION
Needed a way to start print from HA, might be worth sharing.
In general, first tried with `gcode_file` , but could not get that working on my P1, but `project_file` seems to be working as expected.

Inspiration for MQTT payloads was taken from:
- https://github.com/Doridian/OpenBambuAPI/blob/main/mqtt.md#printproject_file
- https://github.com/mattcar15/bambu-connect/blob/main/bambu_connect/ExecuteClient.py#L41